### PR TITLE
Feature: Support BackChannel Authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,9 @@ go 1.19
 require (
 	github.com/coreos/go-oidc/v3 v3.5.0
 	github.com/gin-contrib/cors v1.4.0
-	github.com/gin-contrib/sessions v0.0.5
 	github.com/gin-gonic/gin v1.8.1
+	github.com/go-session/session/v3 v3.1.7
+	github.com/gorilla/securecookie v1.1.1
 	github.com/stretchr/testify v1.8.0
 	github.com/urfave/cli/v2 v2.23.5
 	go.uber.org/zap v1.23.0
@@ -23,9 +24,6 @@ require (
 	github.com/go-playground/validator/v10 v10.10.0 // indirect
 	github.com/goccy/go-json v0.9.7 // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
-	github.com/gorilla/context v1.1.1 // indirect
-	github.com/gorilla/securecookie v1.1.1 // indirect
-	github.com/gorilla/sessions v1.2.1 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/leodido/go-urn v1.2.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,8 +10,6 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gin-contrib/cors v1.4.0 h1:oJ6gwtUl3lqV0WEIwM/LxPF1QZ5qe2lGWdY2+bz7y0g=
 github.com/gin-contrib/cors v1.4.0/go.mod h1:bs9pNM0x/UsmHPBWT2xZz9ROh8xYjYkiURUfmBoMlcs=
-github.com/gin-contrib/sessions v0.0.5 h1:CATtfHmLMQrMNpJRgzjWXD7worTh7g7ritsQfmF+0jE=
-github.com/gin-contrib/sessions v0.0.5/go.mod h1:vYAuaUPqie3WUSsft6HUlCjlwwoJQs97miaG2+7neKY=
 github.com/gin-contrib/sse v0.1.0 h1:Y/yl/+YNO8GZSjAhjMsSuLt29uWRFHdHYUb5lYOV9qE=
 github.com/gin-contrib/sse v0.1.0/go.mod h1:RHrZQHXnP2xjPF+u1gW/2HnVO7nvIa9PG3Gm+fLHvGI=
 github.com/gin-gonic/gin v1.8.1 h1:4+fr/el88TOO3ewCmQr8cx/CtZ/umlIRIs5M4NTNjf8=
@@ -26,6 +24,8 @@ github.com/go-playground/universal-translator v0.18.0 h1:82dyy6p4OuJq4/CByFNOn/j
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=
 github.com/go-playground/validator/v10 v10.10.0 h1:I7mrTYv78z8k8VXa/qJlOlEXn/nBh+BF8dHX5nt/dr0=
 github.com/go-playground/validator/v10 v10.10.0/go.mod h1:74x4gJWsvQexRdW8Pn3dXSGrTK4nAUsbPlLADvpJkos=
+github.com/go-session/session/v3 v3.1.7 h1:itIpJrGInZ4TCcxHM0JhrcQmbAuDTxBKs/RusiZqB/U=
+github.com/go-session/session/v3 v3.1.7/go.mod h1:PieA4nuP9myN/vnXEOMZasQZ28cj77KP2K0SyLiZ6dk=
 github.com/goccy/go-json v0.9.7 h1:IcB+Aqpx/iMHu5Yooh7jEzJk1JZ7Pjtmys2ukPr7EeM=
 github.com/goccy/go-json v0.9.7/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
@@ -37,14 +37,12 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.8 h1:e6P7q2lk1O+qJJb4BtCQXlK8vWEO8V1ZeuEdJNOqZyg=
 github.com/google/go-cmp v0.5.8/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
-github.com/gorilla/context v1.1.1 h1:AWwleXJkX/nhcU9bZSnZoi3h/qGYqQAGhq6zZe/aQW8=
-github.com/gorilla/context v1.1.1/go.mod h1:kBGZzfjB9CEq2AlWe17Uuf7NDRt0dE0s8S51q0aT7Yg=
+github.com/gopherjs/gopherjs v0.0.0-20200217142428-fce0ec30dd00 h1:l5lAOZEym3oK3SQ2HBHWsJUfbNBiTXJDeW2QDxw9AQ0=
 github.com/gorilla/securecookie v1.1.1 h1:miw7JPhV+b/lAHSXz4qd/nN9jRiAFV5FwjeKyCS8BvQ=
 github.com/gorilla/securecookie v1.1.1/go.mod h1:ra0sb63/xPlUeL+yeDciTfxMRAA+MP+HVt/4epWDjd4=
-github.com/gorilla/sessions v1.2.1 h1:DHd3rPN5lE3Ts3D8rKkQ8x/0kqfeNmBAaiSi+o7FsgI=
-github.com/gorilla/sessions v1.2.1/go.mod h1:dk2InVEVJ0sfLlnXv9EAgkf6ecYs/i80K/zI+bUmuGM=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
 github.com/kr/pretty v0.3.0 h1:WgNl7dwNpEZ6jJ9k1snq4pZsg7DOEN8hP9Xw0Tsjwk0=
@@ -64,7 +62,7 @@ github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjY
 github.com/pelletier/go-toml/v2 v2.0.1 h1:8e3L2cCQzLFi2CR4g7vGFuFxX7Jl1kKX8gW+iV0GUKU=
 github.com/pelletier/go-toml/v2 v2.0.1/go.mod h1:r9LEWfGN8R5k0VXJ+0BkIe7MYkRdwZOjgMj2KwnJFUo=
 github.com/pkg/diff v0.0.0-20210226163009-20ebb0f2a09e/go.mod h1:pJLUxLENpZxwdsKMEsNbx1VGcRFpLqf3715MtcvvzbA=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.6.1/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
@@ -72,6 +70,8 @@ github.com/rogpeppe/go-internal v1.8.0 h1:FCbCCtXNOY3UtUuHUYaghJg4y7Fd14rXifAYUA
 github.com/rogpeppe/go-internal v1.8.0/go.mod h1:WmiCO8CzOY8rg0OYDC4/i/2WRWAB6poM+XZ2dLUbcbE=
 github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/smartystreets/assertions v1.1.0 h1:MkTeG1DMwsrdH7QtLXy5W+fUxWq+vmb6cLmyJ7aRtF0=
+github.com/smartystreets/goconvey v1.6.4 h1:fv0U8FUIMPNf1L9lnHLvLhgicrIVChEkdzIKYqbNC9s=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/pkg/cookie/LICENSE
+++ b/pkg/cookie/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Lyric
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/cookie/README.md
+++ b/pkg/cookie/README.md
@@ -1,0 +1,105 @@
+# Cookie store for [Session](https://github.com/go-session/session)
+
+[![Build][Build-Status-Image]][Build-Status-Url] [![Codecov][codecov-image]][codecov-url] [![ReportCard][reportcard-image]][reportcard-url] [![GoDoc][godoc-image]][godoc-url] [![License][license-image]][license-url]
+
+## Quick Start
+
+### Download and install
+
+```bash
+$ go get -u -v github.com/go-session/cookie
+```
+
+### Create file `server.go`
+
+```go
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/go-session/cookie"
+	"github.com/go-session/session"
+)
+
+var (
+	hashKey = []byte("FF51A553-72FC-478B-9AEF-93D6F506DE91")
+)
+
+func main() {
+	session.InitManager(
+		session.SetStore(
+			cookie.NewCookieStore(
+				cookie.SetCookieName("demo_cookie_store_id"),
+				cookie.SetHashKey(hashKey),
+			),
+		),
+	)
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		store, err := session.Start(context.Background(), w, r)
+		if err != nil {
+			fmt.Fprint(w, err)
+			return
+		}
+
+		store.Set("foo", "bar")
+		err = store.Save()
+		if err != nil {
+			fmt.Fprint(w, err)
+			return
+		}
+
+		http.Redirect(w, r, "/foo", 302)
+	})
+
+	http.HandleFunc("/foo", func(w http.ResponseWriter, r *http.Request) {
+		store, err := session.Start(context.Background(), w, r)
+		if err != nil {
+			fmt.Fprint(w, err)
+			return
+		}
+
+		foo, ok := store.Get("foo")
+		if !ok {
+			fmt.Fprint(w, "does not exist")
+			return
+		}
+
+		fmt.Fprintf(w, "foo:%s", foo)
+	})
+
+	http.ListenAndServe(":8080", nil)
+}
+```
+
+### Build and run
+
+```bash
+$ go build server.go
+$ ./server
+```
+
+### Open in your web browser
+
+<http://localhost:8080>
+
+    foo:bar
+
+
+## MIT License
+
+    Copyright (c) 2018 Lyric
+
+[Build-Status-Url]: https://travis-ci.org/go-session/cookie
+[Build-Status-Image]: https://travis-ci.org/go-session/cookie.svg?branch=master
+[codecov-url]: https://codecov.io/gh/go-session/cookie
+[codecov-image]: https://codecov.io/gh/go-session/cookie/branch/master/graph/badge.svg
+[reportcard-url]: https://goreportcard.com/report/github.com/go-session/cookie
+[reportcard-image]: https://goreportcard.com/badge/github.com/go-session/cookie
+[godoc-url]: https://godoc.org/github.com/go-session/cookie
+[godoc-image]: https://godoc.org/github.com/go-session/cookie?status.svg
+[license-url]: http://opensource.org/licenses/MIT
+[license-image]: https://img.shields.io/npm/l/express.svg

--- a/pkg/cookie/cookie.go
+++ b/pkg/cookie/cookie.go
@@ -1,0 +1,248 @@
+package cookie
+
+import (
+	"context"
+	"net/http"
+	"sync"
+	"time"
+
+	"github.com/go-session/session/v3"
+	"github.com/gorilla/securecookie"
+)
+
+var (
+	_ session.ManagerStore = &managerStore{}
+	_ session.Store        = &store{}
+)
+
+// NewCookieStore Create an instance of a cookie store
+func NewCookieStore(opt ...Option) session.ManagerStore {
+	opts := defaultOptions
+	for _, o := range opt {
+		o(&opts)
+	}
+
+	cookie := securecookie.New(opts.hashKey, opts.blockKey)
+	if v := opts.hashFunc; v != nil {
+		cookie = cookie.HashFunc(v)
+	}
+	if v := opts.blockFunc; v != nil {
+		cookie = cookie.BlockFunc(v)
+	}
+	if v := opts.maxLength; v != -1 {
+		cookie = cookie.MaxLength(v)
+	}
+	if v := opts.maxAge; v != -1 {
+		cookie = cookie.MaxAge(v)
+	}
+	if v := opts.minAge; v != -1 {
+		cookie = cookie.MinAge(v)
+	}
+
+	return &managerStore{
+		opts:   opts,
+		cookie: cookie,
+	}
+}
+
+type managerStore struct {
+	cookie *securecookie.SecureCookie
+	opts   options
+}
+
+func (s *managerStore) Create(ctx context.Context, sid string, expired int64) (session.Store, error) {
+	return newStore(ctx, s, sid, expired, nil), nil
+}
+
+func (s *managerStore) Update(ctx context.Context, sid string, expired int64) (session.Store, error) {
+	req, ok := session.FromReqContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+
+	cookie, err := req.Cookie(s.opts.cookieName)
+	if err != nil {
+		return newStore(ctx, s, sid, expired, nil), nil
+	}
+
+	res, ok := session.FromResContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+	cookie.Expires = time.Now().Add(time.Duration(expired) * time.Second)
+	cookie.MaxAge = int(expired)
+	http.SetCookie(res, cookie)
+
+	var values map[string]interface{}
+	err = s.cookie.Decode(sid, cookie.Value, &values)
+	if err != nil {
+		return nil, err
+	}
+
+	return newStore(ctx, s, sid, expired, values), nil
+}
+
+func (s *managerStore) Delete(ctx context.Context, sid string) error {
+	exists, err := s.Check(ctx, sid)
+	if err != nil {
+		return err
+	} else if !exists {
+		return nil
+	}
+
+	res, ok := session.FromResContext(ctx)
+	if !ok {
+		return nil
+	}
+	cookie := &http.Cookie{
+		Name:     s.opts.cookieName,
+		Path:     "/",
+		HttpOnly: true,
+		Expires:  time.Now(),
+		MaxAge:   -1,
+	}
+	http.SetCookie(res, cookie)
+
+	return nil
+}
+
+func (s *managerStore) Check(ctx context.Context, sid string) (bool, error) {
+	req, ok := session.FromReqContext(ctx)
+	if !ok {
+		return false, nil
+	}
+
+	_, err := req.Cookie(s.opts.cookieName)
+	return err == nil, nil
+}
+
+func (s *managerStore) Refresh(ctx context.Context, oldsid, sid string, expired int64) (session.Store, error) {
+	req, ok := session.FromReqContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+
+	cookie, err := req.Cookie(s.opts.cookieName)
+	if err != nil {
+		return newStore(ctx, s, sid, expired, nil), nil
+	}
+
+	var values map[string]interface{}
+	err = s.cookie.Decode(oldsid, cookie.Value, &values)
+	if err != nil {
+		return nil, err
+	}
+
+	encoded, err := s.cookie.Encode(sid, values)
+	if err != nil {
+		return nil, err
+	}
+
+	cookie.Value = encoded
+	cookie.Expires = time.Now().Add(time.Duration(expired) * time.Second)
+	cookie.MaxAge = int(expired)
+	res, ok := session.FromResContext(ctx)
+	if !ok {
+		return nil, nil
+	}
+	http.SetCookie(res, cookie)
+
+	return newStore(ctx, s, sid, expired, values), nil
+}
+
+func (s *managerStore) Close() error {
+	return nil
+}
+
+func newStore(ctx context.Context, s *managerStore, sid string, expired int64, values map[string]interface{}) *store {
+	if values == nil {
+		values = make(map[string]interface{})
+	}
+
+	return &store{
+		opts:    s.opts,
+		cookie:  s.cookie,
+		ctx:     ctx,
+		sid:     sid,
+		expired: expired,
+		values:  values,
+	}
+}
+
+type store struct {
+	sync.RWMutex
+	ctx     context.Context
+	cookie  *securecookie.SecureCookie
+	values  map[string]interface{}
+	sid     string
+	opts    options
+	expired int64
+}
+
+func (s *store) Context() context.Context {
+	return s.ctx
+}
+
+func (s *store) SessionID() string {
+	return s.sid
+}
+
+func (s *store) Set(key string, value interface{}) {
+	s.Lock()
+	s.values[key] = value
+	s.Unlock()
+}
+
+func (s *store) Get(key string) (interface{}, bool) {
+	s.RLock()
+	val, ok := s.values[key]
+	s.RUnlock()
+	return val, ok
+}
+
+func (s *store) Delete(key string) interface{} {
+	s.RLock()
+	v, ok := s.values[key]
+	s.RUnlock()
+	if ok {
+		s.Lock()
+		delete(s.values, key)
+		s.Unlock()
+	}
+	return v
+}
+
+func (s *store) Flush() error {
+	s.Lock()
+	s.values = make(map[string]interface{})
+	s.Unlock()
+	return s.Save()
+}
+
+func (s *store) Save() error {
+	s.RLock()
+	encoded, err := s.cookie.Encode(s.sid, s.values)
+	if err != nil {
+		s.RUnlock()
+		return err
+	}
+	s.RUnlock()
+
+	cookie := &http.Cookie{
+		Name:     s.opts.cookieName,
+		Value:    encoded,
+		Path:     "/",
+		Secure:   s.opts.secure,
+		HttpOnly: true,
+		MaxAge:   int(s.expired),
+		Expires:  time.Now().Add(time.Duration(s.expired) * time.Second),
+	}
+
+	res, ok := session.FromResContext(s.Context())
+	if !ok {
+		return nil
+	}
+
+	http.SetCookie(res, cookie)
+	return nil
+}

--- a/pkg/cookie/cookie_test.go
+++ b/pkg/cookie/cookie_test.go
@@ -1,0 +1,87 @@
+package cookie
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-session/session/v3"
+)
+
+var (
+	hashKey = []byte("FF51A553-72FC-478B-9AEF-93D6F506DE91")
+)
+
+func TestCookie(t *testing.T) {
+	sess := session.NewManager(
+		session.SetCookieName("test_cookie"),
+		session.SetSign([]byte("sign")),
+		session.SetStore(NewCookieStore(
+			SetCookieName("test_cookie_store"),
+			SetHashKey(hashKey),
+		)),
+	)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		store, err := sess.Start(context.Background(), w, r)
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		if r.URL.Query().Get("login") == "1" {
+			foo, ok := store.Get("foo")
+			fmt.Fprintf(w, "%s:%v", foo, ok)
+			return
+		}
+
+		store.Set("foo", "bar")
+		err = store.Save()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+
+		fmt.Fprint(w, "ok")
+	}))
+	defer ts.Close()
+
+	res, err := http.Get(ts.URL)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	buf, _ := io.ReadAll(res.Body)
+	if string(buf) != "ok" {
+		t.Error("Not expected value:", string(buf))
+		return
+	}
+	res.Body.Close()
+
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s?login=1", ts.URL), nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	for _, c := range res.Cookies() {
+		req.AddCookie(c)
+	}
+
+	res, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	buf, _ = io.ReadAll(res.Body)
+	res.Body.Close()
+	if string(buf) != "bar:true" {
+		t.Error("Not expected value:", string(buf))
+		return
+	}
+}

--- a/pkg/cookie/options.go
+++ b/pkg/cookie/options.go
@@ -1,0 +1,92 @@
+package cookie
+
+import (
+	"crypto/cipher"
+	"hash"
+)
+
+// Define default options
+var defaultOptions = options{
+	cookieName: "cookie_session_id",
+	maxLength:  -1,
+	maxAge:     -1,
+	minAge:     -1,
+}
+
+type options struct {
+	hashFunc   func() hash.Hash
+	blockFunc  func([]byte) (cipher.Block, error)
+	cookieName string
+	hashKey    []byte
+	blockKey   []byte
+	maxLength  int
+	maxAge     int
+	minAge     int
+	secure     bool
+}
+
+// Option A cookie parameter options
+type Option func(*options)
+
+// SetCookieName Set the cookie name
+func SetCookieName(cookieName string) Option {
+	return func(o *options) {
+		o.cookieName = cookieName
+	}
+}
+
+// SetSecure Set cookie security
+func SetSecure(secure bool) Option {
+	return func(o *options) {
+		o.secure = secure
+	}
+}
+
+// SetHashKey used to authenticate values using HMAC
+func SetHashKey(hashKey []byte) Option {
+	return func(o *options) {
+		o.hashKey = hashKey
+	}
+}
+
+// SetHashFunc sets the hash function used to create HMAC
+func SetHashFunc(hashFunc func() hash.Hash) Option {
+	return func(o *options) {
+		o.hashFunc = hashFunc
+	}
+}
+
+// SetBlockKey used to encrypt values
+func SetBlockKey(blockKey []byte) Option {
+	return func(o *options) {
+		o.blockKey = blockKey
+	}
+}
+
+// SetBlockFunc sets the encryption function used to create a cipher.Block
+func SetBlockFunc(blockFunc func([]byte) (cipher.Block, error)) Option {
+	return func(o *options) {
+		o.blockFunc = blockFunc
+	}
+}
+
+// SetMaxLength restricts the maximum length, in bytes, for the cookie value
+func SetMaxLength(maxLength int) Option {
+	return func(o *options) {
+		o.maxLength = maxLength
+	}
+}
+
+// SetMaxAge restricts the maximum age, in seconds, for the cookie value
+func SetMaxAge(maxAge int) Option {
+	return func(o *options) {
+		o.maxAge = maxAge
+	}
+}
+
+// SetMinAge restricts the minimum age, in seconds, for the cookie value
+func SetMinAge(minAge int) Option {
+	return func(o *options) {
+		o.minAge = minAge
+	}
+}

--- a/pkg/ginsession/LICENSE
+++ b/pkg/ginsession/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2018 Lyric
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pkg/ginsession/README.md
+++ b/pkg/ginsession/README.md
@@ -1,0 +1,85 @@
+# Session middleware for [Gin](https://github.com/gin-gonic/gin)
+
+[![Build][Build-Status-Image]][Build-Status-Url] [![Codecov][codecov-image]][codecov-url] [![ReportCard][reportcard-image]][reportcard-url] [![GoDoc][godoc-image]][godoc-url] [![License][license-image]][license-url]
+
+Forked from https://github.com/go-session/gin-session/ and updated for go-session/gin-session/v3
+
+## Quick Start
+
+### Download and install
+
+```bash
+$ go get -u -v github.com/go-session/gin-session
+```
+
+### Create file `server.go`
+
+```go
+package main
+
+import (
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-session/gin-session"
+)
+
+func main() {
+	app := gin.Default()
+
+	app.Use(ginsession.New())
+
+	app.GET("/", func(ctx *gin.Context) {
+		store := ginsession.FromContext(ctx)
+		store.Set("foo", "bar")
+		err := store.Save()
+		if err != nil {
+			_ = ctx.AbortWithError(500, err)
+			return
+		}
+
+		ctx.Redirect(302, "/foo")
+	})
+
+	app.GET("/foo", func(ctx *gin.Context) {
+		store := ginsession.FromContext(ctx)
+		foo, ok := store.Get("foo")
+		if !ok {
+			ctx.AbortWithStatus(404)
+			return
+		}
+		ctx.String(http.StatusOK, "foo:%s", foo)
+	})
+
+	app.Run(":8080")
+}
+```
+
+### Build and run
+
+```bash
+$ go build server.go
+$ ./server
+```
+
+### Open in your web browser
+
+<http://localhost:8080>
+
+    foo:bar
+
+
+## MIT License
+
+    Copyright (c) 2018 Lyric
+
+[Build-Status-Url]: https://travis-ci.org/go-session/gin-session
+[Build-Status-Image]: https://travis-ci.org/go-session/gin-session.svg?branch=master
+[codecov-url]: https://codecov.io/gh/go-session/gin-session
+[codecov-image]: https://codecov.io/gh/go-session/gin-session/branch/master/graph/badge.svg
+[reportcard-url]: https://goreportcard.com/report/github.com/go-session/gin-session
+[reportcard-image]: https://goreportcard.com/badge/github.com/go-session/gin-session
+[godoc-url]: https://godoc.org/github.com/go-session/gin-session
+[godoc-image]: https://godoc.org/github.com/go-session/gin-session?status.svg
+[license-url]: http://opensource.org/licenses/MIT
+[license-image]: https://img.shields.io/npm/l/express.svg

--- a/pkg/ginsession/session.go
+++ b/pkg/ginsession/session.go
@@ -1,0 +1,109 @@
+package ginsession
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-session/session/v3"
+)
+
+type (
+	// ErrorHandleFunc error handling function
+	ErrorHandleFunc func(*gin.Context, error)
+	// Config defines the config for Session middleware
+	Config struct {
+		// error handling when starting the session
+		ErrorHandleFunc ErrorHandleFunc
+		// keys stored in the context
+		StoreKey string
+		// keys stored in the context
+		ManageKey string
+		// defines a function to skip middleware.Returning true skips processing
+		// the middleware.
+		Skipper func(*gin.Context) bool
+	}
+)
+
+var (
+	storeKey  string
+	manageKey string
+
+	// DefaultConfig is the default Recover middleware config.
+	DefaultConfig = Config{
+		ErrorHandleFunc: func(ctx *gin.Context, err error) {
+			_ = ctx.AbortWithError(500, err)
+		},
+		StoreKey:  "github.com/go-session/gin-session/store",
+		ManageKey: "github.com/go-session/gin-session/manage",
+		Skipper: func(_ *gin.Context) bool {
+			return false
+		},
+	}
+)
+
+// New create a session middleware
+func New(opt ...session.Option) gin.HandlerFunc {
+	return NewWithConfig(DefaultConfig, opt...)
+}
+
+// NewWithConfig create a session middleware
+func NewWithConfig(config Config, opt ...session.Option) gin.HandlerFunc {
+	if config.ErrorHandleFunc == nil {
+		config.ErrorHandleFunc = DefaultConfig.ErrorHandleFunc
+	}
+
+	manageKey = config.ManageKey
+	if manageKey == "" {
+		manageKey = DefaultConfig.ManageKey
+	}
+
+	storeKey = config.StoreKey
+	if storeKey == "" {
+		storeKey = DefaultConfig.StoreKey
+	}
+
+	manage := session.NewManager(opt...)
+	return func(ctx *gin.Context) {
+		if config.Skipper != nil && config.Skipper(ctx) {
+			ctx.Next()
+			return
+		}
+
+		ctx.Set(manageKey, manage)
+		store, err := manage.Start(context.Background(), ctx.Writer, ctx.Request)
+		if err != nil {
+			config.ErrorHandleFunc(ctx, err)
+			return
+		}
+		ctx.Set(storeKey, store)
+		ctx.Next()
+	}
+}
+
+// FromContext Get session storage from context
+func FromContext(ctx *gin.Context) session.Store {
+	v, ok := ctx.Get(storeKey)
+	if ok {
+		return v.(session.Store)
+	}
+	return nil
+}
+
+// Destroy a session
+func Destroy(ctx *gin.Context) error {
+	v, ok := ctx.Get(manageKey)
+	if !ok {
+		return fmt.Errorf("invalid session manager")
+	}
+	return v.(*session.Manager).Destroy(ctx.Request.Context(), ctx.Writer, ctx.Request)
+}
+
+// Refresh a session and return to session storage
+func Refresh(ctx *gin.Context) (session.Store, error) {
+	v, ok := ctx.Get(manageKey)
+	if !ok {
+		return nil, fmt.Errorf("invalid session manager")
+	}
+	return v.(*session.Manager).Refresh(ctx.Request.Context(), ctx.Writer, ctx.Request)
+}

--- a/pkg/ginsession/session_test.go
+++ b/pkg/ginsession/session_test.go
@@ -1,0 +1,80 @@
+package ginsession
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/go-session/session/v3"
+)
+
+func TestSession(t *testing.T) {
+	cookieName := "test_gin_session"
+
+	gin.SetMode(gin.ReleaseMode)
+	r := gin.New()
+	r.Use(New(
+		session.SetCookieName(cookieName),
+		session.SetSign([]byte("sign")),
+	))
+
+	r.Use(func(ctx *gin.Context) {
+		store := FromContext(ctx)
+		if ctx.Query("login") == "1" {
+			foo, ok := store.Get("foo")
+			fmt.Fprintf(ctx.Writer, "%s:%v", foo, ok)
+			return
+		}
+
+		store.Set("foo", "bar")
+		err := store.Save()
+		if err != nil {
+			t.Error(err)
+			return
+		}
+		fmt.Fprint(ctx.Writer, "ok")
+	})
+
+	w := httptest.NewRecorder()
+	req, err := http.NewRequest("GET", "/", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	r.ServeHTTP(w, req)
+
+	res := w.Result()
+	cookie := res.Cookies()[0]
+	if cookie.Name != cookieName {
+		t.Error("Not expected value:", cookie.Name)
+		return
+	}
+
+	buf, _ := io.ReadAll(res.Body)
+	res.Body.Close()
+	if string(buf) != "ok" {
+		t.Error("Not expected value:", string(buf))
+		return
+	}
+
+	req, err = http.NewRequest("GET", "/?login=1", nil)
+	if err != nil {
+		t.Error(err)
+		return
+	}
+	req.AddCookie(cookie)
+
+	w = httptest.NewRecorder()
+	r.ServeHTTP(w, req)
+
+	res = w.Result()
+	buf, _ = io.ReadAll(res.Body)
+	res.Body.Close()
+	if string(buf) != "bar:true" {
+		t.Error("Not expected value:", string(buf))
+		return
+	}
+}

--- a/router.go
+++ b/router.go
@@ -4,9 +4,10 @@ import (
 	"encoding/gob"
 
 	"github.com/gin-contrib/cors"
-	"github.com/gin-contrib/sessions"
-	"github.com/gin-contrib/sessions/cookie"
 	"github.com/gin-gonic/gin"
+	"github.com/go-session/session/v3"
+	"github.com/redhat-et/go-oidc-agent/pkg/cookie"
+	"github.com/redhat-et/go-oidc-agent/pkg/ginsession"
 	"golang.org/x/oauth2"
 )
 
@@ -18,8 +19,15 @@ func NewCodeFlowRouter(auth *OidcAgent) *gin.Engine {
 	r := gin.Default()
 	r.Use(auth.OriginVerifier())
 
-	store := cookie.NewStore([]byte(auth.cookieKey))
-	r.Use(sessions.Sessions(SessionStorage, store))
+	session.InitManager(
+		session.SetStore(
+			cookie.NewCookieStore(
+				cookie.SetHashKey([]byte(auth.cookieKey)),
+			),
+		),
+	)
+
+	r.Use(ginsession.New())
 
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowCredentials = true


### PR DESCRIPTION
This adds support for using backchannel authentication. For example, your users authenticate using a public URL, but you are adjacent to the auth server which you can reach via a K8s cluster.local address. TLS is still required, but we skip certificate validation since the cert cannot be signed for the back channel URL.

This also swaps out the gin-contrib session middleware for go-session. Serializing the entire *oauth2.Token was with gob was surpassing the MaxLength - we encode it to string now. This size limitation also followed when using memcache or other storage options. go-session doesn't have this size limit for other storage options, but still relies on gorilla/securecookie for cookie storage.

Signed-off-by: Dave Tucker <dave@dtucker.co.uk>